### PR TITLE
Fix column_default in Postgres 12

### DIFF
--- a/postgresql_autodoc.pl
+++ b/postgresql_autodoc.pl
@@ -391,7 +391,7 @@ sub info_collect {
                                   AND relkind = 'S') THEN
                 NULL
               ELSE
-                adsrc
+                pg_get_expr(adbin, adrelid)
               END as column_default
             , pg_catalog.col_description(attrelid, attnum) as column_description
             , attnum


### PR DESCRIPTION
The adsrc column doesn't exist in Postgres 12. This PR fixes the query, and works as far back as Postgres 9.0.