### PR TITLE
Add Postgres port to Dockerfile environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ RUN make install
 
 ENV DATABASE=app \
   HOST=localhost \
+  PORT=port \
   USER=app \
   PASSWORD=password
 
 CMD postgresql_autodoc -d ${DATABASE} \
   -h ${HOST} \
+  -p ${PORT} \
   -u ${USER} \
   --password=${PASSWORD}

--- a/env-example
+++ b/env-example
@@ -1,5 +1,6 @@
 # Copy, rename to env, and fill in your db details
 DATABASE=app
 HOST=localhost
+PORT=5432
 USER=app
 PASSWORD=password


### PR DESCRIPTION
I'm running Postgres in different port than default 5432. Dockerfile's CMD `postgresql_autodoc` had no `-p` parameter configured, so I needed to modify Dockerfile.

This change makes it possible to user to define Postgres port in `env` file when using autodoc with Docker.